### PR TITLE
Fix Local File Inclusion Vulnerability in ViewSource Function. Version <= v0.9.2

### DIFF
--- a/StaticAnalyzer/views.py
+++ b/StaticAnalyzer/views.py
@@ -269,6 +269,8 @@ def ViewSource(request):
         if m and (request.GET['file'].endswith('.java') or request.GET['file'].endswith('.smali')):
             fil=request.GET['file']
             MD5=request.GET['md5']
+            if (("../" in MD5) or ("%2e%2e" in MD5) or (".." in MD5) or ("%252e" in MD5)):
+                return HttpResponseRedirect('/error/')
             if (("../" in fil) or ("%2e%2e" in fil) or (".." in fil) or ("%252e" in fil)):
                 return HttpResponseRedirect('/error/')
             else:


### PR DESCRIPTION
Hi Ajin,

I've found a Local File Inclusion Vulnerablity in StaticAnalyzer/views.py (Version <= v0.9.2)

**Detail:** Bypass "md5" varriable by
- An actual md5 string (e.g: an uploaded file) at the head.
- Null-byte at the end of string

**PoC**:
http://127.0.0.1:8000/ViewSource/
?file=de/robv/android/xposed/installer/repo/RepoDb.java
&md5=_36570c6fac687ffe08107e6a72bd3da7/../../../../../../../../../../../private/etc/passwd%00_
&type=apk

**Before fixing: read /private/etc/passwd on MAC OS**
![1_modsf_v0 9 2_lfi_unfix](https://cloud.githubusercontent.com/assets/5011906/15568942/b51daf4c-2358-11e6-9c73-71de9b78781e.png)
**After Fixed**
![2_modsf_v0 9 2_lfi_fixed](https://cloud.githubusercontent.com/assets/5011906/15568941/b5199aa6-2358-11e6-879b-f77492ee8d81.png)

I'm still working on contributing this great project.
Thanks for all