### PR TITLE
PYTHON3 PATH Fix

### DIFF
--- a/StaticAnalyzer/views.py
+++ b/StaticAnalyzer/views.py
@@ -1024,7 +1024,7 @@ def WinFixPython3(TOOLS_DIR):
                 for path in paths:
                     if "python3" in path.lower():
                         PYTHON3_PATH = path
-        PYTHON3 = os.path.join(PYTHON3_PATH,"python")
+        PYTHON3 = "\"" + os.path.join(PYTHON3_PATH,"python") + "\""
         DMY=os.path.join(TOOLS_DIR,'enjarify/enjarify.tmp')
         ORG=os.path.join(TOOLS_DIR,'enjarify/enjarify.bat')
         dat=''


### PR DESCRIPTION
* Code Breaks on Windows systems if path contains space.
* Issue was pointed out by @allyshka
* Fix for #176 