### PR TITLE
Real Device Bug fix

### DIFF
--- a/DynamicAnalyzer/views.py
+++ b/DynamicAnalyzer/views.py
@@ -992,7 +992,8 @@ def GetRes():
 def getIdentifier():
     try:
         if settings.REAL_DEVICE:
-            return settings.DEVICE_IP + ":" + str(settings.DEVICE_ADB_PORT)
+            return settings.DEVICE_SERIALNUMBER
+            #return settings.DEVICE_IP + ":" + str(settings.DEVICE_ADB_PORT)
         else:
             return settings.VM_IP + ":" + str(settings.VM_ADB_PORT)
     except:

--- a/MobSF/settings.py
+++ b/MobSF/settings.py
@@ -259,7 +259,7 @@ else:
 
     #===============DEVICE SETTINGS=================
     REAL_DEVICE = False
-    #Device IP make many bugs ,we can use device serial number instead . by CplusHua
+    #Device IP makes many bugs ,we can use device serial number instead . by CplusHua
     #adb get-serialno 
     DEVICE_SERIALNUMBER =''
     DEVICE_IP = '192.168.1.18'

--- a/MobSF/settings.py
+++ b/MobSF/settings.py
@@ -259,6 +259,9 @@ else:
 
     #===============DEVICE SETTINGS=================
     REAL_DEVICE = False
+    #Device IP make many bugs ,we can use device serial number instead . by CplusHua
+    #adb get-serialno 
+    DEVICE_SERIALNUMBER =''
     DEVICE_IP = '192.168.1.18'
     DEVICE_ADB_PORT = 5555
     DEVICE_TIMEOUT = 300


### PR DESCRIPTION
I have met an error when I am using a real device to test my apps. And I just find that there is a bug lead to this, " adb -s 192.168.1.1:5555 shell" is not a right way to operate the real device . 
[adb help](https://developer.android.com/studio/command-line/adb.html)

> -s <serialNumber>

I think we can use serial number instead of IP to fix this bug. 